### PR TITLE
if parameters.isc doesn't exist, don't try to switch to manager user

### DIFF
--- a/instance_test.go
+++ b/instance_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/user"
 	"syscall"
 	"time"
@@ -192,6 +193,7 @@ var _ = Describe("Instance", func() {
 			})
 		})
 	})
+
 	Describe("DetermineISCDatFileName", func() {
 		Context("The product is Cache", func() {
 			It("Returns the correct DAT filename", func() {
@@ -547,6 +549,25 @@ var _ = Describe("Instance", func() {
 				It("returns the default session command", func() {
 					Expect(instance.controlPath()).To(Equal(globalIrisPath))
 				})
+			})
+		})
+	})
+
+	Describe("Update", func() {
+		// To test instance updates when running somewhere that doesn't actually have access to the
+		// parameters.isc file, such as `iscenv` wrapping `csession` or `iris`
+		Context("Valid qlist without parameters.isc", func() {
+			BeforeEach(func() {
+				parameterReader = func(directory string, file string) (io.ReadCloser, error) {
+					return nil, os.ErrNotExist
+				}
+				instance, err = InstanceFromQList(cacheqlist)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("Does not return an error", func() {
+				err := instance.Update()
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
if using a tool like `iscenv` that can wrap `iris` or `csession`, you could have valid looking `iris qlist` without actually being able to read the `parameters.isc` file or switch to the manager user.

This had worked previously, but stopped working in [v2.2.11](https://github.com/ontariosystems/isclib/releases/tag/v2.2.11)